### PR TITLE
Specify an icon pixel size for the OS Logo Icon

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -141,6 +141,7 @@ public class About.Plug : Switchboard.Plug {
     private void setup_ui () {
         // Create the section about elementary OS
         var logo = new Gtk.Image.from_icon_name ("distributor-logo", Gtk.icon_size_register ("LOGO", 128, 128));
+        logo.pixel_size = 128;
         logo.hexpand = true;
 
         var title = new Gtk.Label (os);


### PR DESCRIPTION
Fixes #31 

This PR specifies an pixel_size for the OS Logo Icon, which ensures that it's displayed at the right size even if an icon theme without 128px icons is used. The icon size matches the size that is originally requested, so there shouldn't be any conflicts with the elementary theme.