### PR TITLE
Fix a few deprecation warnings

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -139,7 +139,8 @@ public class About.Plug : Switchboard.Plug {
     // Wires up and configures initial UI
     private void setup_ui () {
         // Create the section about elementary OS
-        var logo = new Gtk.Image.from_icon_name ("distributor-logo", Gtk.icon_size_register ("LOGO", 128, 128));
+        var logo = new Gtk.Image ();
+        logo.icon_name = "distributor-logo";
         logo.pixel_size = 128;
         logo.hexpand = true;
 

--- a/src/RestoreDialog.vala
+++ b/src/RestoreDialog.vala
@@ -40,7 +40,7 @@ public class RestoreDialog : Gtk.Dialog {
         var grid = new Gtk.Grid ();
         grid.column_spacing = 12;
         grid.row_spacing = 6;
-        grid.margin_left = grid.margin_right = 12;
+        grid.margin_start = grid.margin_end = 12;
         grid.attach (image, 0, 0, 1, 2);
         grid.attach (primary_label, 1, 0, 1, 1);
         grid.attach (secondary_label, 1, 1, 1, 1);
@@ -56,7 +56,7 @@ public class RestoreDialog : Gtk.Dialog {
         add_action_widget (continue_button, 1);
 
         var action_area = get_action_area ();
-        action_area.margin_right = 6;
+        action_area.margin_end = 6;
         action_area.margin_bottom = 6;
         action_area.margin_top = 14;
     }


### PR DESCRIPTION
* `margin_right` and `margin_left` have been replaced by `margin_end` and `margin_start`
* `Gtk.icon_size_register` is deprecated so just use `icon_name` on a separate line