### PR TITLE
Fix layout

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -258,8 +258,8 @@ public class About.Plug : Switchboard.Plug {
         description_grid.valign = Gtk.Align.CENTER;
         description_grid.vexpand = true;
         description_grid.column_spacing = 24;
-        description_grid.margin_left = 12;
-        description_grid.margin_right = 12;
+        description_grid.margin_start = 12;
+        description_grid.margin_end = 12;
         description_grid.add (software_grid);
         description_grid.add (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         description_grid.add (hardware_view);

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -258,6 +258,8 @@ public class About.Plug : Switchboard.Plug {
         description_grid.valign = Gtk.Align.CENTER;
         description_grid.vexpand = true;
         description_grid.column_spacing = 24;
+        description_grid.margin_left = 12;
+        description_grid.margin_right = 12;
         description_grid.add (software_grid);
         description_grid.add (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         description_grid.add (hardware_view);

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -41,24 +41,30 @@ public class About.HardwareView : Gtk.Grid {
 
         var manufacturer_logo = new Gtk.Image ();
         manufacturer_logo.icon_name = system_interface.icon_name;
+        manufacturer_logo.hexpand = true;
         manufacturer_logo.pixel_size = 128;
         manufacturer_logo.use_fallback = true;
 
         var product_name_info = new Gtk.Label (Environment.get_host_name ());
+        product_name_info.ellipsize = Pango.EllipsizeMode.END;
         product_name_info.get_style_context ().add_class ("h2");
         product_name_info.set_selectable (true);
 
         var processor_info = new Gtk.Label (processor);
+        processor_info.ellipsize = Pango.EllipsizeMode.END;
         processor_info.margin_top = 12;
         processor_info.set_selectable (true);
 
         var memory_info = new Gtk.Label (_("%s memory").printf (memory));
+        memory_info.ellipsize = Pango.EllipsizeMode.END;
         memory_info.set_selectable (true);
 
         var graphics_info = new Gtk.Label (graphics);
+        graphics_info.ellipsize = Pango.EllipsizeMode.END;
         graphics_info.set_selectable (true);
 
         var hdd_info = new Gtk.Label (_("%s storage").printf (hdd));
+        hdd_info.ellipsize = Pango.EllipsizeMode.END;
         hdd_info.set_selectable (true);
 
         column_spacing = 6;
@@ -165,7 +171,7 @@ public class About.HardwareView : Gtk.Grid {
             }
         }
 
-        //Memory
+        // Memory
         memory = GLib.format_size (get_mem_info ());
 
         // Graphics

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -84,6 +84,7 @@ public class About.HardwareView : Gtk.Grid {
             }
 
             var manufacturer_info = new Gtk.Label (manufacturer_name);
+            manufacturer_info.ellipsize = Pango.EllipsizeMode.END;
             manufacturer_info.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
             manufacturer_info.set_selectable (true);
 
@@ -91,14 +92,15 @@ public class About.HardwareView : Gtk.Grid {
 
             if (product_name != null) {
                 product_name_info.label = product_name;
-                product_name_info.xalign = 1;
             }
 
             if (product_version != null) {
                 var product_version_info = new Gtk.Label ("(" + product_version + ")");
                 product_version_info.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
                 product_version_info.set_selectable (true);
+                product_version_info.ellipsize = Pango.EllipsizeMode.END;
                 product_version_info.xalign = 0;
+                product_name_info.xalign = 1;
                 attach (product_name_info, 0, 1, 1, 1);
                 attach (product_version_info, 1, 1, 1, 1);
             } else {


### PR DESCRIPTION
* make sure that images are the same distance from separator
* added left margin to software and right margin to hardware so that grids are centered evenly between window edge and separator when you downsize window 
* use ellipsis on hardware labels so that window doesn't auto-resize if text is too big
* oem product was aligned on right if there was no oem version provided