### PR TITLE
Add new RDNN keys to reset

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -301,7 +301,7 @@ public class About.Plug : Switchboard.Plug {
     private static string[] get_pantheon_schemas () {
         string[] schemas = {};
         string[] pantheon_schemas = {};
-        string[] prefixes = { "org.pantheon.desktop", "org.gnome.desktop" };
+        string[] prefixes = { "org.pantheon.desktop", "io.elementary.desktop", "org.gnome.desktop" };
     
         var sss = SettingsSchemaSource.get_default ();
     


### PR DESCRIPTION
Don't remove the org.pantheon keys because Gala still uses that settings path