### PR TITLE
Fix wrong GitHub URL for switchboard-plug-display

### DIFF
--- a/src/Dialogs/IssueDialog.vala
+++ b/src/Dialogs/IssueDialog.vala
@@ -288,7 +288,7 @@ public class About.IssueDialog : Granite.MessageDialog {
             name = "Displays",
             gettext_domain = "pantheon-display-plug",
             icon = "preferences-desktop-display",
-            github_suffix = "switchboard-plug-displays"
+            github_suffix = "switchboard-plug-display"
         },
         SwitchboardEntry () {
             name = "Keyboard",


### PR DESCRIPTION
Fixes https://github.com/elementary/switchboard-plug-display/issues/132
Fixes #73 