### PR TITLE
Show what kind of storage is used

### DIFF
--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -294,7 +294,13 @@ public class About.HardwareView : Gtk.Grid {
             string contents;
             FileUtils.get_contents (path, out contents);
             if (int.parse (contents) == 0) {
-                storage = _("SSD");
+                if (disk_name.has_prefix ("nvme")) {
+                    storage = _("NVMe SSD");
+                } else if (disk_name.has_prefix ("mmc")) {
+                    storage = _("eMMC");
+                } else {
+                    storage = _("SATA SSD");
+                }
             } else {
                 storage = _("HDD");
             }

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -293,14 +293,14 @@ public class About.HardwareView : Gtk.Grid {
             FileUtils.get_contents (path, out contents);
             if (int.parse (contents) == 0) {
                 if (disk_name.has_prefix ("nvme")) {
-                    storage = _("NVMe SSD");
+                    storage = _("storage (NVMe SSD)");
                 } else if (disk_name.has_prefix ("mmc")) {
-                    storage = _("eMMC");
+                    storage = _("storage (eMMC)");
                 } else {
-                    storage = _("SATA SSD");
+                    storage = _("storage (SATA SSD)");
                 }
             } else {
-                storage = _("HDD");
+                storage = _("storage (HDD)");
             }
         } catch (FileError e) {
             warning (e.message);

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -64,7 +64,7 @@ public class About.HardwareView : Gtk.Grid {
         graphics_info.justify = Gtk.Justification.CENTER;
         graphics_info.set_selectable (true);
 
-        ///TRANSLATORS: The first %s represents capacity of system strage.
+        ///TRANSLATORS: The first %s represents capacity of system storage.
         ///The second one is its type: whether HDD or SSD.
         var hdd_info = new Gtk.Label (_("%s %s").printf (hdd, get_storage_type ()));
         hdd_info.ellipsize = Pango.EllipsizeMode.END;

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -65,7 +65,9 @@ public class About.HardwareView : Gtk.Grid {
         graphics_info.justify = Gtk.Justification.CENTER;
         graphics_info.set_selectable (true);
 
-        var hdd_info = new Gtk.Label (_("%s storage %s").printf (hdd, storage_type));
+        ///TRANSLATORS: The first %s represents capacity of system strage.
+        ///The second one is its type: whether HDD or SSD.
+        var hdd_info = new Gtk.Label (_("%s %s").printf (hdd, storage_type));
         hdd_info.ellipsize = Pango.EllipsizeMode.END;
         hdd_info.set_selectable (true);
 
@@ -292,9 +294,9 @@ public class About.HardwareView : Gtk.Grid {
             string contents;
             FileUtils.get_contents (path, out contents);
             if (int.parse (contents) == 0) {
-                storage = _("(SSD)");
+                storage = _("SSD");
             } else {
-                storage = _("(HDD)");
+                storage = _("HDD");
             }
         } catch (FileError e) {
             warning (e.message);

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -65,7 +65,9 @@ public class About.HardwareView : Gtk.Grid {
         graphics_info.set_selectable (true);
 
         ///TRANSLATORS: "%1$s" represents capacity of system storage.
-        ///"%2$s" represents its type: NVMe SSD / eMMC / SATA SSD / HDD.
+        ///"%2$s" contains the string "storage" and storage type (NVMe SSD/eMMC/SATA SSD/HDD).
+        ///e.g. if a system strage has 240 GB capacity and its type is SATA SSD,
+        ///this label looks like: "240 GB storage (SATA SSD)"
         var hdd_info = new Gtk.Label (_("%1$s %2$s").printf (hdd, get_storage_type ()));
         hdd_info.ellipsize = Pango.EllipsizeMode.END;
         hdd_info.set_selectable (true);

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -304,7 +304,7 @@ public class About.HardwareView : Gtk.Grid {
             }
         } catch (FileError e) {
             warning (e.message);
-            storage = _("Unknown");
+            storage = _("Storage");
         }
         return storage;
     }

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -65,7 +65,7 @@ public class About.HardwareView : Gtk.Grid {
         graphics_info.set_selectable (true);
 
         ///TRANSLATORS: The first %s represents capacity of system storage.
-        ///The second one is its type: whether HDD or SSD.
+        ///The second one is its type: NVMe SSD / eMMC / SATA SSD / HDD.
         var hdd_info = new Gtk.Label (_("%s %s").printf (hdd, get_storage_type ()));
         hdd_info.ellipsize = Pango.EllipsizeMode.END;
         hdd_info.set_selectable (true);

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -304,7 +304,8 @@ public class About.HardwareView : Gtk.Grid {
             }
         } catch (FileError e) {
             warning (e.message);
-            storage = _("Storage");
+            // Set fallback string for the device type
+            storage = _("storage");
         }
         return storage;
     }

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -64,9 +64,9 @@ public class About.HardwareView : Gtk.Grid {
         graphics_info.justify = Gtk.Justification.CENTER;
         graphics_info.set_selectable (true);
 
-        ///TRANSLATORS: The first %s represents capacity of system storage.
-        ///The second one is its type: NVMe SSD / eMMC / SATA SSD / HDD.
-        var hdd_info = new Gtk.Label (_("%s %s").printf (hdd, get_storage_type ()));
+        ///TRANSLATORS: "%1$s" represents capacity of system storage.
+        ///"%2$s" represents its type: NVMe SSD / eMMC / SATA SSD / HDD.
+        var hdd_info = new Gtk.Label (_("%1$s %2$s").printf (hdd, get_storage_type ()));
         hdd_info.ellipsize = Pango.EllipsizeMode.END;
         hdd_info.set_selectable (true);
 

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -304,6 +304,7 @@ public class About.HardwareView : Gtk.Grid {
             }
         } catch (FileError e) {
             warning (e.message);
+            storage = _("Unknown");
         }
         return storage;
     }

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -21,7 +21,6 @@ public class About.HardwareView : Gtk.Grid {
     private bool oem_enabled;
     private string graphics;
     private string hdd;
-    private string storage_type;
     private string manufacturer_icon_path;
     private string manufacturer_name;
     private string manufacturer_support_url;
@@ -67,7 +66,7 @@ public class About.HardwareView : Gtk.Grid {
 
         ///TRANSLATORS: The first %s represents capacity of system strage.
         ///The second one is its type: whether HDD or SSD.
-        var hdd_info = new Gtk.Label (_("%s %s").printf (hdd, storage_type));
+        var hdd_info = new Gtk.Label (_("%s %s").printf (hdd, get_storage_type ()));
         hdd_info.ellipsize = Pango.EllipsizeMode.END;
         hdd_info.set_selectable (true);
 
@@ -210,7 +209,6 @@ public class About.HardwareView : Gtk.Grid {
         try {
             var info = file_root.query_filesystem_info (GLib.FileAttribute.FILESYSTEM_SIZE, null);
             hdd = GLib.format_size (info.get_attribute_uint64 (GLib.FileAttribute.FILESYSTEM_SIZE));
-            storage_type = get_storage_type ();
         } catch (Error e) {
             critical (e.message);
             hdd = _("Unknown");


### PR DESCRIPTION
Fixes #63
Supersedes #67

I made this PR because it looks like the branch of that PR no longer exists :cry:
The original PR checks whether system storage is SSD or HDD, but this PR also recognizes whether it's NVMe, eMMC, or SATA.

## Changes Summary

* Show whether the system storage is NVMe SSD / eMMC / SATA SSD / HDD (#67 + α)

## How it Looks Like

### With NVMe SSD

![Screenshot from 2019-06-29 20-53-33](https://user-images.githubusercontent.com/26003928/60383830-68398600-9ab1-11e9-9c62-1458d77e21f9.png)

### With SATA SSD

![Screenshot from 2019-06-29 20-57-09](https://user-images.githubusercontent.com/26003928/60383832-6bcd0d00-9ab1-11e9-9b1f-5e782ab5b168.png)

### With SATA HDD

![Screenshot from 2019-06-29 21-02-23](https://user-images.githubusercontent.com/26003928/60383836-6ff92a80-9ab1-11e9-9c8f-245299fc9ae5.png)
