### PR TITLE
Get GPU model from SessionManager

### DIFF
--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -35,14 +35,13 @@ public class About.HardwareView : Gtk.Grid {
     private SessionManager session_manager;
 
     construct {
-
         try {
             session_manager = Bus.get_proxy_sync (BusType.SESSION,
                 "org.gnome.SessionManager", "/org/gnome/SessionManager");
         } catch (IOError e) {
             critical (e.message);
+            graphics = _("Unknown");
         }
-
 
         fetch_hardware_info ();
 
@@ -192,12 +191,7 @@ public class About.HardwareView : Gtk.Grid {
         memory = GLib.format_size (get_mem_info ());
 
         // Graphics
-        try {
-            graphics = clean_graphics_name (session_manager.renderer);
-        } catch (Error e) {
-            warning (e.message);
-            graphics = _("Unknown");
-        }
+        graphics = clean_graphics_name (session_manager.renderer);
 
         // Hard Drive
         var file_root = GLib.File.new_for_path ("/");
@@ -351,8 +345,8 @@ public class About.HardwareView : Gtk.Grid {
     }
 
     struct GraphicsReplaceStrings {
-      string regex;
-      string replacement;
+        string regex;
+        string replacement;
     }
 }
 

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -34,7 +34,8 @@ public class About.HardwareView : Gtk.Grid {
     construct {
 
         try {
-            session_manager = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.SessionManager", "/org/gnome/SessionManager");
+            session_manager = Bus.get_proxy_sync (BusType.SESSION,
+                "org.gnome.SessionManager", "/org/gnome/SessionManager");
         } catch (IOError e) {
             critical (e.message);
         }
@@ -43,7 +44,8 @@ public class About.HardwareView : Gtk.Grid {
         fetch_hardware_info ();
 
         try {
-            system_interface = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.hostname1", "/org/freedesktop/hostname1");
+            system_interface = Bus.get_proxy_sync (BusType.SYSTEM,
+                "org.freedesktop.hostname1", "/org/freedesktop/hostname1");
         } catch (IOError e) {
             critical (e.message);
         }
@@ -188,7 +190,7 @@ public class About.HardwareView : Gtk.Grid {
 
         // Graphics
         try {
-            graphics = clean_graphics_name(session_manager.renderer);
+            graphics = clean_graphics_name (session_manager.renderer);
         } catch (Error e) {
             warning (e.message);
             graphics = _("Unknown");
@@ -237,12 +239,12 @@ public class About.HardwareView : Gtk.Grid {
         }
     }
 
-    private string clean_graphics_name(string info){
+    private string clean_graphics_name (string info){
 
-        string escaped = GLib.Markup.escape_text(info);
-        string pretty = escaped.strip();
+        string escaped = GLib.Markup.escape_text (info);
+        string pretty = escaped.strip ();
 
-        const GraphicsReplaceStrings replace_strings[] = {
+        const GraphicsReplaceStrings REPLACE_STRINGS[] = {
             { "Mesa DRI ", ""},
             { "Intel[(]R[)]", "Intel\u00ae"},
             { "Core[(]TM[)]", "Core\u209c\u2098"},
@@ -255,9 +257,9 @@ public class About.HardwareView : Gtk.Grid {
         };
 
 
-        foreach(GraphicsReplaceStrings replace_string in replace_strings){
-            GLib.Regex re = new GLib.Regex(replace_string.regex,0,0);
-            pretty = re.replace(pretty,-1,0,replace_string.replacement,0);
+        foreach(GraphicsReplaceStrings replace_string in REPLACE_STRINGS){
+            GLib.Regex re = new GLib.Regex (replace_string.regex,0,0);
+            pretty = re.replace (pretty,-1,0,replace_string.replacement,0);
         }
 
         return pretty;

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -1,5 +1,8 @@
 /*
+* Copyright (C) 2010 Red Hat, Inc
+* Copyright (C) 2008 William Jon McCann <jmccann@redhat.com>
 * Copyright (c) 2017 elementary LLC. (https://elementary.io)
+* Copyright (C) 2020 Justin Haygood <jhaygood86@gmail.com>
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -241,25 +244,25 @@ public class About.HardwareView : Gtk.Grid {
 
     private string clean_graphics_name (string info) {
 
-        string escaped = GLib.Markup.escape_text (info);
-        string pretty = escaped.strip ();
+        string pretty = GLib.Markup.escape_text (info).strip();
 
         const GraphicsReplaceStrings REPLACE_STRINGS[] = {
             { "Mesa DRI ", ""},
-            { "Intel[(]R[)]", "Intel\u00ae"},
-            { "Core[(]TM[)]", "Core\u209c\u2098"},
-            { "Atom[(]TM[)]", "Atom\u2098"},
+            { "[(]R[)]", "®"},
+            { "[(]TM[)]", "™"},
             { "Gallium .* on (AMD .*)", "\\1"},
             { "(AMD .*) [(].*", "\\1"},
             { "(AMD [A-Z])(.*)", "\\1\\L\\2\\E"},
-            { "AMD", "AMD"},
             { "Graphics Controller", "Graphics"},
         };
 
-
-        foreach (GraphicsReplaceStrings replace_string in REPLACE_STRINGS) {
-            GLib.Regex re = new GLib.Regex (replace_string.regex, 0, 0);
-            pretty = re.replace (pretty, -1, 0, replace_string.replacement, 0);
+        try {
+            foreach (GraphicsReplaceStrings replace_string in REPLACE_STRINGS) {
+                GLib.Regex re = new GLib.Regex (replace_string.regex, 0, 0);
+                pretty = re.replace (pretty, -1, 0, replace_string.replacement, 0);
+            }
+        } catch (Error e) {
+            critical ("Couldn't pretty graphics string: %s", e.message);
         }
 
         return pretty;

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -244,7 +244,7 @@ public class About.HardwareView : Gtk.Grid {
 
     private string clean_graphics_name (string info) {
 
-        string pretty = GLib.Markup.escape_text (info).strip();
+        string pretty = GLib.Markup.escape_text (info).strip ();
 
         const GraphicsReplaceStrings REPLACE_STRINGS[] = {
             { "Mesa DRI ", ""},

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -257,7 +257,7 @@ public class About.HardwareView : Gtk.Grid {
         };
 
 
-        foreach(GraphicsReplaceStrings replace_string in REPLACE_STRINGS) {
+        foreach (GraphicsReplaceStrings replace_string in REPLACE_STRINGS) {
             GLib.Regex re = new GLib.Regex (replace_string.regex, 0, 0);
             pretty = re.replace (pretty, -1, 0, replace_string.replacement, 0);
         }
@@ -347,8 +347,7 @@ public class About.HardwareView : Gtk.Grid {
         return disk_name;
     }
 
-    struct GraphicsReplaceStrings
-    {
+    struct GraphicsReplaceStrings {
       string regex;
       string replacement;
     }
@@ -362,6 +361,6 @@ public interface SystemInterface : Object {
 
 [DBus (name = "org.gnome.SessionManager")]
 public interface SessionManager : Object {
-    [DBus(name = "Renderer")]
+    [DBus (name = "Renderer")]
     public abstract string renderer { owned get;}
 }

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -239,7 +239,7 @@ public class About.HardwareView : Gtk.Grid {
         }
     }
 
-    private string clean_graphics_name (string info){
+    private string clean_graphics_name (string info) {
 
         string escaped = GLib.Markup.escape_text (info);
         string pretty = escaped.strip ();
@@ -257,9 +257,9 @@ public class About.HardwareView : Gtk.Grid {
         };
 
 
-        foreach(GraphicsReplaceStrings replace_string in REPLACE_STRINGS){
-            GLib.Regex re = new GLib.Regex (replace_string.regex,0,0);
-            pretty = re.replace (pretty,-1,0,replace_string.replacement,0);
+        foreach(GraphicsReplaceStrings replace_string in REPLACE_STRINGS) {
+            GLib.Regex re = new GLib.Regex (replace_string.regex, 0, 0);
+            pretty = re.replace (pretty, -1, 0, replace_string.replacement, 0);
         }
 
         return pretty;


### PR DESCRIPTION
Fixes #106 

Supersedes #125 

This is @jhaygood86 's work from that original PR, I've just pushed an extra commit with some requested fixes after the PR went stale.

As an aside, this allows the about plug to correctly display the GPU in my Pinebook Pro where it previously displayed nothing.