### PR TITLE
libgtop-2.0: Replace GLib.PtrArray by GLib.GenericArray

### DIFF
--- a/vapi/libgtop-2.0.vapi
+++ b/vapi/libgtop-2.0.vapi
@@ -21,7 +21,7 @@ namespace GLibTop {
 
     [CCode (cheader_filename = "glibtop/sysinfo.h", destroy_function = "")]
     public struct entry {
-        public GLib.PtrArray labels;
+        public GLib.GenericArray labels;
         public GLib.HashTable values;
         public GLib.HashTable descriptions;
     }


### PR DESCRIPTION
GLib.GenericArray is the vala-binding version of GLib.PtrArray