### PR TITLE
OSView: Remove GTK version

### DIFF
--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -71,13 +71,6 @@ public class About.OperatingSystemView : Gtk.Grid {
             xalign = 0
         };
 
-        var gtk_version_label = new Gtk.Label (_("GTK %u.%u.%u").printf (
-            Gtk.get_major_version (), Gtk.get_minor_version (), Gtk.get_micro_version ()
-        )) {
-            selectable = true,
-            xalign = 0
-        };
-
         var website_url = Environment.get_os_info (GLib.OsInfoKey.HOME_URL);
         if (website_url == "" || website_url == null) {
             website_url = "https://elementary.io";
@@ -144,8 +137,7 @@ public class About.OperatingSystemView : Gtk.Grid {
         }
 
         software_grid.attach (kernel_version_label, 1, 2);
-        software_grid.attach (gtk_version_label, 1, 3);
-        software_grid.attach (website_label, 1, 4);
+        software_grid.attach (website_label, 1, 3);
 
         orientation = Gtk.Orientation.VERTICAL;
         halign = Gtk.Align.CENTER;


### PR DESCRIPTION
This was useful and made sense in a world with unstable GTK 3 API, but in a flatpak world where apps may be using their own GTK version this only tells us what version of GTK is being used by the about plug. So it's not terribly useful anymore