### PR TITLE
HardwareView: Use 24px of column spacing

### DIFF
--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -150,7 +150,7 @@ public class About.HardwareView : Gtk.Grid {
             details_grid.add (manufacturer_website_info);
         }
 
-        column_spacing = 12;
+        column_spacing = 24;
         halign = Gtk.Align.CENTER;
 
         add (manufacturer_logo);


### PR DESCRIPTION
More breathing room for logos.

![Screenshot from 2021-01-04 20-45-19](https://user-images.githubusercontent.com/611168/103604262-c5e03700-4ecd-11eb-93bb-6d7329d1d74d.png)
