### PR TITLE
Use field ELEMENTARY_UPSTREAM_DISTRO_NAME

### DIFF
--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -153,7 +153,6 @@ public class About.OperatingSystemView : Gtk.Grid {
         software_grid.attach (translate_button, 3, 3);
 
         orientation = Gtk.Orientation.VERTICAL;
-        column_spacing = 24;
         row_spacing = 12;
         add (software_grid);
         add (button_grid);

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -23,9 +23,7 @@ public class About.OperatingSystemView : Gtk.Grid {
 
     construct {
         // Upstream distro version (for "Built on" text)
-        // FIXME: Add distro specific field to /etc/os-release and use that instead
-        // Like "ELEMENTARY_UPSTREAM_DISTRO_NAME" or something
-        var file = File.new_for_path ("/etc/upstream-release/lsb-release");
+        var file = File.new_for_path ("/etc/os-release");
         string upstream_release = null;
         try {
             var dis = new DataInputStream (file.read ());
@@ -33,9 +31,14 @@ public class About.OperatingSystemView : Gtk.Grid {
             // Read lines until end of file (null) is reached
             while ((line = dis.read_line (null)) != null) {
                 var distrib_component = line.split ("=", 2);
-                if (distrib_component.length == 2) {
-                    upstream_release = distrib_component[1].replace ("\"", "");
+                if (distrib_component.length == 2 && distrib_component[0] == "ELEMENTARY_UPSTREAM_DISTRO_NAME") {
+                    upstream_release = distrib_component[1];
+                    break;
                 }
+            }
+            // Remove quotation marks
+            if (upstream_release.contains ("\"")) {
+                upstream_release = upstream_release.replace ("\"", "");
             }
         } catch (Error e) {
             warning ("Couldn't read upstream lsb-release file, assuming none");
@@ -150,6 +153,7 @@ public class About.OperatingSystemView : Gtk.Grid {
         software_grid.attach (translate_button, 3, 3);
 
         orientation = Gtk.Orientation.VERTICAL;
+        column_spacing = 24;
         row_spacing = 12;
         add (software_grid);
         add (button_grid);


### PR DESCRIPTION
As requested in

https://github.com/elementary/switchboard-plug-about/blob/6fb20637ad257253a21aaeca164830d68da55836/src/Views/OperatingSystemView.vala#L26-L27

(though this two tab view is probably still being iterated on). Atm you can add the field `ELEMENTARY_UPSTREAM_DISTRO_NAME` to `/etc/os-release`. I'm guessing I'll need to make a PR to [os-patches](https://github.com/elementary/os-patches) to add this field so if someone could guide me that would be nice.

Preview:

![Screenshot from 2021-01-05 22 11 56](https://user-images.githubusercontent.com/31680656/103656015-0b226880-4fa3-11eb-953f-de0318ba5f63.png)
