### PR TITLE
OperatingSystemView: Add Keyboard indicator settings to reset

### DIFF
--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -266,6 +266,7 @@ public class About.OperatingSystemView : Gtk.Grid {
             "org.pantheon.desktop",
             "io.elementary.desktop",
             "io.elementary.onboarding",
+            "io.elementary.wingpanel.keyboard",
             "org.gnome.desktop",
             "org.gnome.settings-daemon"
         };


### PR DESCRIPTION
I noticed we weren't resetting these.