### PR TITLE
Fix logic if device is up to date

### DIFF
--- a/src/Widgets/FirmwareUpdateRow.vala
+++ b/src/Widgets/FirmwareUpdateRow.vala
@@ -72,7 +72,7 @@ public class About.Widgets.FirmwareUpdateRow : Gtk.ListBoxRow {
         }
 
         if (is_updatable) {
-            version_label.label = release.get_version ();
+            version_label.label = "%s → %s".printf (device.get_version (), release.get_version ());
 
             var update_button = new Gtk.Button.with_label (_("Update")) {
                 valign = Gtk.Align.CENTER


### PR DESCRIPTION
The port to libfwupd has introduced a regression related to the logic of whether a device is up to date.

## Before

![Bildschirmfoto von 2021-03-07 16 46 04](https://user-images.githubusercontent.com/10796736/110246195-eaf13480-7f66-11eb-8d7c-9f671b53286d.png)

![Bildschirmfoto von 2021-03-07 16 46 56](https://user-images.githubusercontent.com/10796736/110246201-f04e7f00-7f66-11eb-826d-32e4492d069f.png)

## After

![Bildschirmfoto von 2021-03-07 16 56 53](https://user-images.githubusercontent.com/10796736/110246205-f47a9c80-7f66-11eb-98e4-e60f56e027ea.png)

In both cases, "Unifying Receiver" is at version RQR12.07_B0029 which is lower than the latest release RQR12.10_B0032.