### PR TITLE
Handle long hardware names

### DIFF
--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -45,33 +45,33 @@ public class About.HardwareView : Gtk.Grid {
         fetch_hardware_info ();
 
         var product_name_info = new Gtk.Label (Environment.get_host_name ()) {
-            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize = Pango.EllipsizeMode.MIDDLE,
             selectable = true,
             xalign = 0
         };
         product_name_info.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
         var processor_info = new Gtk.Label (processor) {
-            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize = Pango.EllipsizeMode.MIDDLE,
             margin_top = 12,
             selectable = true,
             xalign = 0
         };
 
         var memory_info = new Gtk.Label (_("%s memory").printf (memory)) {
-            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize = Pango.EllipsizeMode.MIDDLE,
             selectable = true,
             xalign = 0
         };
 
         primary_graphics_info = new Gtk.Label (_("Unknown Graphics")) {
-            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize = Pango.EllipsizeMode.MIDDLE,
             selectable = true,
             xalign = 0
         };
 
         secondary_graphics_info = new Gtk.Label (null) {
-            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize = Pango.EllipsizeMode.MIDDLE,
             selectable = true,
             xalign = 0
         };
@@ -84,7 +84,7 @@ public class About.HardwareView : Gtk.Grid {
         graphics_grid.add (primary_graphics_info);
 
         storage_info = new Gtk.Label (_("Unknown storage")) {
-            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize = Pango.EllipsizeMode.MIDDLE,
             selectable = true,
             xalign = 0
         };
@@ -117,7 +117,7 @@ public class About.HardwareView : Gtk.Grid {
             }
 
             var manufacturer_info = new Gtk.Label (manufacturer_name) {
-                ellipsize = Pango.EllipsizeMode.END,
+                ellipsize = Pango.EllipsizeMode.MIDDLE,
                 selectable = true,
                 xalign = 0
             };

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -152,6 +152,8 @@ public class About.HardwareView : Gtk.Grid {
             details_grid.add (manufacturer_website_info);
         }
 
+        margin_left = 32;
+        margin_right = 32;
         column_spacing = 32;
         halign = Gtk.Align.CENTER;
 

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -152,8 +152,8 @@ public class About.HardwareView : Gtk.Grid {
             details_grid.add (manufacturer_website_info);
         }
 
-        margin_left = 32;
-        margin_right = 32;
+        margin_left = 16;
+        margin_right = 16;
         column_spacing = 32;
         halign = Gtk.Align.CENTER;
 


### PR DESCRIPTION
- Use middle ellipsis in hardware names to make sure it's easy to distinguish the devices and also, in the case of audio devices, to be consistent with how the indicator displays them.

- Add margin to the left and right so long hardware names are properly displayed.

Before and after:

![bug_before](https://user-images.githubusercontent.com/1335948/118925035-49129e80-b93e-11eb-8be0-e5a93751ba95.png)


![bug_after](https://user-images.githubusercontent.com/1335948/118925042-4d3ebc00-b93e-11eb-8108-e35f0686b927.png)
