### PR TITLE
OperatingSystemView: display PRETTY_NAME when possible

### DIFF
--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -68,12 +68,25 @@ public class About.OperatingSystemView : Gtk.Grid {
         logo_overlay.add (logo);
         logo_overlay.add_overlay (icon);
 
-        // Intentionally not using GLib.OsInfoKey.PRETTY_NAME here because we
-        // want more granular control over text formatting
+        // Use GLib.OsInfoKey.PRETTY_NAME only when GLib.OsInfoKey.NAME is a
+        // prefix of it so we can get more granular control over text formatting
+        var os_name = Environment.get_os_info (GLib.OsInfoKey.NAME);
+        var os_version = Environment.get_os_info (GLib.OsInfoKey.VERSION);
+        var os_pretty_name = Environment.get_os_info (GLib.OsInfoKey.PRETTY_NAME);
+
         var pretty_name = "<b>%s</b> %s".printf (
-            Environment.get_os_info (GLib.OsInfoKey.NAME),
-            Environment.get_os_info (GLib.OsInfoKey.VERSION)
+            os_name,
+            os_version
         );
+
+        if (os_pretty_name != null
+            && os_name != null
+            && os_pretty_name.has_prefix (os_name + " ")) {
+            pretty_name = "<b>%s</b>%s".printf (
+                os_name,
+                os_pretty_name.slice (os_name.length, os_pretty_name.length)
+            );
+        }
 
         var title = new Gtk.Label (pretty_name) {
             ellipsize = Pango.EllipsizeMode.END,


### PR DESCRIPTION
Implementation of https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-885147633.

`VERSION` in NixOS is a bit too long to display in the latest switchboard:

```
NAME=NixOS
ID=nixos
VERSION="21.11.git.165c18ade65 (Porcupine)"
VERSION_CODENAME=porcupine
VERSION_ID="21.11.git.165c18ade65"
PRETTY_NAME="NixOS 21.11 (Porcupine)"
LOGO="nix-snowflake"
HOME_URL="https://nixos.org/"
DOCUMENTATION_URL="https://nixos.org/learn.html"
SUPPORT_URL="https://nixos.org/community.html"
BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
```

It will be great if we can display `PRETTY_NAME` when `NAME` is a prefix of it so we can still make `NAME` bold.
The currently used `NAME` + `VERSION` way can be used as an alternative if the requirements are not satisfied.
See below screenshot for reference.

![](https://user-images.githubusercontent.com/20080233/126737794-49cf8c73-72f6-46c9-9033-f99eddc15460.png)

Thanks in advance for reviewing :-)