### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -19,4 +19,5 @@
 
 namespace About {
     private const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    private const string LOCALEDIR = "@LOCALEDIR@";
 }

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -27,6 +27,9 @@ public class About.Plug : Switchboard.Plug {
     private Gtk.Stack stack;
 
     public Plug () {
+        GLib.Intl.bindtextdomain (About.GETTEXT_PACKAGE, About.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (About.GETTEXT_PACKAGE, "UTF-8");
+
         var settings = new Gee.TreeMap<string, string?> (null, null);
         settings.set ("about", null);
         settings.set ("about/os", OPERATING_SYSTEM);

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,7 +14,8 @@ switchboard_dep = dependency('switchboard-2.0')
 switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 
 config_data = configuration_data()
-config_data.set('GETTEXT_PACKAGE', meson.project_name())
+config_data.set('GETTEXT_PACKAGE', meson.project_name() + '-plug')
+config_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config_vala = configure_file(
     input: 'Config.vala.in',
     output: '@BASENAME@',


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)