### PR TITLE
Avoid ugly (null) label on some rolling releases distributions

### DIFF
--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -72,7 +72,7 @@ public class About.OperatingSystemView : Gtk.Grid {
         // want more granular control over text formatting
         var pretty_name = "<b>%s</b> %s".printf (
             Environment.get_os_info (GLib.OsInfoKey.NAME),
-            Environment.get_os_info (GLib.OsInfoKey.VERSION)
+            Environment.get_os_info (GLib.OsInfoKey.VERSION) ?? ""
         );
 
         var title = new Gtk.Label (pretty_name) {


### PR DESCRIPTION
With the patch attached, the "(null)" string interpolation of missing OS version is removed from the operating system name label.

With that patch applied, the about window looks like this:

![Capture du 2021-12-22 19-27-04](https://user-images.githubusercontent.com/349239/147139227-d51f9840-d9a8-4fbf-a56d-35ae46b5f15b.png)

This fix #237 