### PR TITLE
Handle Ryzen CPU and AMD GPU vendor string and break on first regex match

### DIFF
--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -257,7 +257,7 @@ public class About.HardwareView : Gtk.Grid {
             } else if (cpu.@value == 6) {
                 result += _("Hexa-Core %s").printf (clean_name (cpu.key));
             } else {
-                result += "%u\u00D7 %s ".printf (cpu.@value, clean_name (cpu.key));
+                result += "%u \u00D7 %s ".printf (cpu.@value, clean_name (cpu.key));
             }
         }
 
@@ -410,23 +410,29 @@ public class About.HardwareView : Gtk.Grid {
 
         string pretty = GLib.Markup.escape_text (info).strip ();
 
-        const GraphicsReplaceStrings REPLACE_STRINGS[] = {
+        const ReplaceStrings REPLACE_STRINGS[] = {
             { "Mesa DRI ", ""},
             { "Mesa (.*)", "\\1"},
             { "[(]R[)]", "®"},
             { "[(]TM[)]", "™"},
             { "Gallium .* on (AMD .*)", "\\1"},
             { "(AMD .*) [(].*", "\\1"},
+            { "(AMD Ryzen) (.*)", "\\1 \\2"},
             { "(AMD [A-Z])(.*)", "\\1\\L\\2\\E"},
+            { "Advanced Micro Devices, Inc\\. \\[.*?\\] .*? \\[(.*?)\\] .*", "\\1"},
             { "Graphics Controller", "Graphics"},
             { "Intel Corporation", "Intel®"},
             { "NVIDIA Corporation (.*) \\[(\\S*) (\\S*) (.*)\\]", "NVIDIA® \\2® \\3® \\4"}
         };
 
         try {
-            foreach (GraphicsReplaceStrings replace_string in REPLACE_STRINGS) {
+            foreach (ReplaceStrings replace_string in REPLACE_STRINGS) {
                 GLib.Regex re = new GLib.Regex (replace_string.regex, 0, 0);
+                bool matched = re.match (pretty);
                 pretty = re.replace (pretty, -1, 0, replace_string.replacement, 0);
+                if (matched) {
+                    break;
+                }
             }
         } catch (Error e) {
             critical ("Couldn't cleanup vendor string: %s", e.message);
@@ -501,7 +507,7 @@ public class About.HardwareView : Gtk.Grid {
         return disk_name;
     }
 
-    struct GraphicsReplaceStrings {
+    struct ReplaceStrings {
         string regex;
         string replacement;
     }

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -419,7 +419,8 @@ public class About.HardwareView : Gtk.Grid {
             { "(AMD .*) [(].*", "\\1"},
             { "(AMD Ryzen) (.*)", "\\1 \\2"},
             { "(AMD [A-Z])(.*)", "\\1\\L\\2\\E"},
-            { "Advanced Micro Devices, Inc\\. \\[.*?\\] .*? \\[(.*?)\\] .*", "\\1"},
+            { "Advanced Micro Devices, Inc\\. \\[.*?\\] .*? \\[(.*?)\\] .*", "AMD® \\1"},
+            { "Advanced Micro Devices, Inc\\. \\[.*?\\] (.*)", "AMD® \\1"},
             { "Graphics Controller", "Graphics"},
             { "Intel Corporation", "Intel®"},
             { "NVIDIA Corporation (.*) \\[(\\S*) (\\S*) (.*)\\]", "NVIDIA® \\2® \\3® \\4"}


### PR DESCRIPTION
Some fixups to handle specific Ryzen CPU and AMD GPU vendor strings in the regex replacement cleanup method.

Also, break after the first regex match, so the replacement strings are in order of preference now.

Before: (note the lowercasing of the cpu string and lengthy gpu string)

![about_before](https://user-images.githubusercontent.com/612302/192748550-d80dc07c-6291-45e1-bb41-2d304295d8ac.jpeg)

After: (note the generic gpu string part matched, instead of the "RX 570" trailer because the actual gpu is an RX 580)

![about_after](https://user-images.githubusercontent.com/612302/192748579-6c787c8f-7b9f-4b9d-bafb-2203726dc8f6.jpeg)
