### PR TITLE
Better memory and storage info

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y meson libfwupd-dev libgranite-dev libgtk-3-dev libgtop2-dev libhandy-1-dev libswitchboard-2.0-dev libappstream-dev valac
+        apt install -y meson libfwupd-dev libgranite-dev libgtk-3-dev libgtop2-dev libgudev-1.0-dev libudisks2-dev libhandy-1-dev libswitchboard-2.0-dev libappstream-dev valac
     - name: Build
       env:
         DESTDIR: out

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You'll need the following dependencies:
 * libgtk-3-dev
 * libgtop2-dev
 * libgudev-1.0-dev
+* libudisks2-dev
 * libhandy-1-dev
 * libappstream-dev
 * meson

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You'll need the following dependencies:
 * libgranite-dev
 * libgtk-3-dev
 * libgtop2-dev
+* libgudev-1.0-dev
 * libhandy-1-dev
 * libappstream-dev
 * meson

--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -420,7 +420,7 @@ public class About.HardwareView : Gtk.Grid {
 
         try {
             UDisks.Client client = yield new UDisks.Client (null);
-            foreach (var object in client.object_manager.get_objects ()) {
+            foreach (unowned var object in client.object_manager.get_objects ()) {
                 UDisks.Drive drive = ((UDisks.Object)object).drive;
                 if (drive == null || drive.removable || drive.ejectable) {
                     continue;

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,6 +35,7 @@ shared_module(
         dependency('granite'),
         dependency('gtk+-3.0'),
         dependency('libgtop-2.0'),
+        dependency('gudev-1.0'),
         dependency('libhandy-1'),
         dependency ('appstream', version: '>=0.12.10'),
         meson.get_compiler('vala').find_library('posix'),

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,6 +36,7 @@ shared_module(
         dependency('gtk+-3.0'),
         dependency('libgtop-2.0'),
         dependency('gudev-1.0'),
+        dependency('udisks2'),
         dependency('libhandy-1'),
         dependency ('appstream', version: '>=0.12.10'),
         meson.get_compiler('vala').find_library('posix'),


### PR DESCRIPTION
Stolen code from GNOME settings repo to use UDev and UDisks libraries to get more accurate memory and storage info.

Memory now shows the physical RAM capacity and storage code collects the total size of all non-removable and non-ejectable disks.

Before: (note the non-physical RAM size using glibtop.mem library and storage size of the root partition only)

![about_before2](https://user-images.githubusercontent.com/612302/193419738-8fa07bc7-22b1-4f21-a7be-4a9c6792e73f.png)

After: (note the more accurate physical RAM size and storage size of the physical disk)

![about_after2](https://user-images.githubusercontent.com/612302/193419741-bc8e39b6-b536-4c5d-8dbc-73f4ea1047f1.png)
