### PR TITLE
Reboot to Firmware Setup

### DIFF
--- a/src/Interfaces/LoginManager.vala
+++ b/src/Interfaces/LoginManager.vala
@@ -23,6 +23,7 @@
 public interface About.LoginInterface : Object {
     public abstract void reboot (bool interactive) throws GLib.Error;
     public abstract void power_off (bool interactive) throws GLib.Error;
+    public abstract void set_reboot_to_firmware_setup (bool interactive) throws GLib.Error;
 }
 
 public class About.LoginManager : Object {
@@ -67,5 +68,13 @@ public class About.LoginManager : Object {
         }
 
         return true;
+    }
+
+    public void set_reboot_to_firmware_setup () {
+        try {
+            interface.set_reboot_to_firmware_setup (true);
+        } catch (Error e) {
+            warning ("Could not connect to login interface: %s", e.message);
+        }
     }
 }

--- a/src/Interfaces/LoginManager.vala
+++ b/src/Interfaces/LoginManager.vala
@@ -71,15 +71,15 @@ public class About.LoginManager : Object {
         return true;
     }
 
-    public bool set_reboot_to_firmware_setup () {
+    public Error? set_reboot_to_firmware_setup () {
         try {
             interface.set_reboot_to_firmware_setup (true);
         } catch (Error e) {
-            warning ("Could not connect to login interface: %s", e.message);
-            return false;
+            warning ("Could not set reboot to firmware setup: %s", e.message);
+            return e;
         }
 
-        return true;
+        return null;
     }
 
     public bool can_reboot_to_firmware_setup () {

--- a/src/Interfaces/LoginManager.vala
+++ b/src/Interfaces/LoginManager.vala
@@ -24,6 +24,7 @@ public interface About.LoginInterface : Object {
     public abstract void reboot (bool interactive) throws GLib.Error;
     public abstract void power_off (bool interactive) throws GLib.Error;
     public abstract void set_reboot_to_firmware_setup (bool interactive) throws GLib.Error;
+    public abstract string can_reboot_to_firmware_setup () throws GLib.Error;
 }
 
 public class About.LoginManager : Object {
@@ -76,5 +77,15 @@ public class About.LoginManager : Object {
         } catch (Error e) {
             warning ("Could not connect to login interface: %s", e.message);
         }
+    }
+
+    public bool can_reboot_to_firmware_setup () {
+        try {
+            return interface.can_reboot_to_firmware_setup () == "yes";
+        } catch (Error e) {
+            warning ("Could not connect to login interface: %s", e.message);
+        }
+
+        return false;
     }
 }

--- a/src/Interfaces/LoginManager.vala
+++ b/src/Interfaces/LoginManager.vala
@@ -71,12 +71,15 @@ public class About.LoginManager : Object {
         return true;
     }
 
-    public void set_reboot_to_firmware_setup () {
+    public bool set_reboot_to_firmware_setup () {
         try {
             interface.set_reboot_to_firmware_setup (true);
         } catch (Error e) {
             warning ("Could not connect to login interface: %s", e.message);
+            return false;
         }
+
+        return true;
     }
 
     public bool can_reboot_to_firmware_setup () {

--- a/src/Views/FirmwareView.vala
+++ b/src/Views/FirmwareView.vala
@@ -401,7 +401,7 @@ public class About.FirmwareView : Granite.SimpleSettingsPage {
 
     private Granite.MessageDialog create_confirm_reboot_to_firmware_setup_dialog () {
         var dialog = new Granite.MessageDialog.with_image_from_icon_name (
-            _("Restart to firmware setup?"),
+            _("Restart to firmware setup"),
             _("This will close all open applications, restart this device, and open the firmware setup screen."),
             "system-reboot",
             Gtk.ButtonsType.CANCEL

--- a/src/Views/FirmwareView.vala
+++ b/src/Views/FirmwareView.vala
@@ -432,7 +432,7 @@ public class About.FirmwareView : Granite.SimpleSettingsPage {
 
             login_manager.reboot ();
         });
-        
+
         dialog.show ();
     }
 

--- a/src/Views/FirmwareView.vala
+++ b/src/Views/FirmwareView.vala
@@ -426,7 +426,7 @@ public class About.FirmwareView : Granite.SimpleSettingsPage {
             var login_manager = LoginManager.get_instance ();
 
             if (!login_manager.set_reboot_to_firmware_setup ()) {
-                // TODO(meisenzahl): throw an error to the user that we're unable to restart into the firmware setup screen
+                show_reboot_to_firmware_setup_error_dialog ();
                 return;
             }
 
@@ -434,5 +434,22 @@ public class About.FirmwareView : Granite.SimpleSettingsPage {
         });
         
         dialog.show ();
+    }
+
+    private void show_reboot_to_firmware_setup_error_dialog () {
+        var gicon = new ThemedIcon ("system-reboot");
+
+        var message_dialog = new Granite.MessageDialog (
+            _("Restart to firmware setup"),
+            _("Unable to restart to firmware setup."),
+            gicon,
+            Gtk.ButtonsType.CLOSE
+        ) {
+            badge_icon = new ThemedIcon ("dialog-error"),
+            transient_for = (Gtk.Window) get_toplevel ()
+        };
+        message_dialog.show_all ();
+        message_dialog.show ();
+        message_dialog.destroy ();
     }
 }

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -125,8 +125,6 @@ public class About.OperatingSystemView : Gtk.Grid {
 
         var settings_restore_button = new Gtk.Button.with_label (_("Restore Default Settings"));
 
-        var reboot_to_firmware_setup_button = new Gtk.Button.with_label (_("Restart to Firmware Setup"));
-
         var button_grid = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL) {
             hexpand = true,
             layout_style = Gtk.ButtonBoxStyle.END,
@@ -134,11 +132,6 @@ public class About.OperatingSystemView : Gtk.Grid {
         };
         button_grid.add (settings_restore_button);
         button_grid.set_child_secondary (settings_restore_button, true);
-        if (LoginManager.get_instance ().can_reboot_to_firmware_setup ()) {
-            button_grid.add (reboot_to_firmware_setup_button);
-            button_grid.set_child_secondary (reboot_to_firmware_setup_button, true);
-        }
-        button_grid.set_child_secondary (reboot_to_firmware_setup_button, true);
         button_grid.add (bug_button);
         if (update_button != null) {
             button_grid.add (update_button);
@@ -168,8 +161,6 @@ public class About.OperatingSystemView : Gtk.Grid {
         show_all ();
 
         settings_restore_button.clicked.connect (settings_restore_clicked);
-
-        reboot_to_firmware_setup_button.clicked.connect (reboot_to_firmware_setup_clicked);
 
         bug_button.clicked.connect (() => {
             var appinfo = new GLib.DesktopAppInfo ("io.elementary.feedback.desktop");
@@ -255,43 +246,6 @@ public class About.OperatingSystemView : Gtk.Grid {
                 reset_recursively (schema);
             }
         }
-    }
-
-    private Granite.MessageDialog create_confirm_reboot_to_firmware_setup_dialog () {
-        var dialog = new Granite.MessageDialog.with_image_from_icon_name (
-            _("Restart to firmware setup?"),
-            _("This will close all open applications, restart this device, and open the firmware setup screen."),
-            "system-reboot",
-            Gtk.ButtonsType.CANCEL
-        );
-        dialog.transient_for = (Gtk.Window) get_toplevel ();
-
-        var continue_button = dialog.add_button (_("Restart"), Gtk.ResponseType.ACCEPT);
-        continue_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-
-        return dialog;
-    }
-
-    private void reboot_to_firmware_setup_clicked () {
-        var dialog = create_confirm_reboot_to_firmware_setup_dialog ();
-        dialog.response.connect ((result) => {
-            dialog.destroy ();
-
-            if (result != Gtk.ResponseType.ACCEPT) {
-                return;
-            }
-
-            var login_manager = LoginManager.get_instance ();
-
-            if (!login_manager.set_reboot_to_firmware_setup ()) {
-                // TODO(meisenzahl): throw an error to the user that we're unable to restart into the firmware setup screen
-                return;
-            }
-
-            login_manager.reboot ();
-        });
-        
-        dialog.show ();
     }
 
     private static void reset_all_keys (GLib.Settings settings) {

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -279,7 +279,11 @@ public class About.OperatingSystemView : Gtk.Grid {
         if (confirm_reboot_to_firmware_setup_action ()) {
             var login_manager = LoginManager.get_instance ();
 
-            login_manager.set_reboot_to_firmware_setup ();
+            if (!login_manager.set_reboot_to_firmware_setup ()) {
+                // TODO(meisenzahl): throw an error to the user that we're unable to restart into the firmware setup screen
+                return;
+            }
+
             login_manager.reboot ();
         }
     }

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -125,7 +125,7 @@ public class About.OperatingSystemView : Gtk.Grid {
 
         var settings_restore_button = new Gtk.Button.with_label (_("Restore Default Settings"));
 
-        var reboot_to_firmware_setup_button = new Gtk.Button.with_label (_("Reboot to Firmware Setup"));
+        var reboot_to_firmware_setup_button = new Gtk.Button.with_label (_("Restart to Firmware Setup"));
 
         var button_grid = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL) {
             hexpand = true,
@@ -259,14 +259,14 @@ public class About.OperatingSystemView : Gtk.Grid {
 
     private bool confirm_reboot_to_firmware_setup_action () {
         var dialog = new Granite.MessageDialog.with_image_from_icon_name (
-            _("Are you sure you want to Reboot?"),
-            _("This will close all open applications and turn off this device."),
-            "system-shutdown",
+            _("Restart to firmware setup?"),
+            _("This will close all open applications, restart this device, and open the firmware setup screen."),
+            "system-reboot",
             Gtk.ButtonsType.CANCEL
         );
         dialog.transient_for = (Gtk.Window) get_toplevel ();
 
-        var continue_button = dialog.add_button (_("Reboot"), Gtk.ResponseType.ACCEPT);
+        var continue_button = dialog.add_button (_("Restart"), Gtk.ResponseType.ACCEPT);
         continue_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
         var result = dialog.run ();

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -131,11 +131,11 @@ public class About.OperatingSystemView : Gtk.Grid {
             spacing = 6
         };
         button_grid.add (settings_restore_button);
-        button_grid.set_child_secondary (settings_restore_button, true);
         button_grid.add (bug_button);
         if (update_button != null) {
             button_grid.add (update_button);
         }
+        button_grid.set_child_secondary (settings_restore_button, true);
 
         software_grid = new Gtk.Grid () {
             // The avatar has some built-in margin for shadows

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -166,6 +166,8 @@ public class About.OperatingSystemView : Gtk.Grid {
 
         settings_restore_button.clicked.connect (settings_restore_clicked);
 
+        reboot_to_firmware_setup_button.clicked.connect (reboot_to_firmware_setup_clicked);
+
         bug_button.clicked.connect (() => {
             var appinfo = new GLib.DesktopAppInfo ("io.elementary.feedback.desktop");
             if (appinfo != null) {
@@ -249,6 +251,33 @@ public class About.OperatingSystemView : Gtk.Grid {
             foreach (var schema in all_schemas) {
                 reset_recursively (schema);
             }
+        }
+    }
+
+    private bool confirm_reboot_to_firmware_setup_action () {
+        var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+            _("Are you sure you want to Reboot?"),
+            _("This will close all open applications and turn off this device."),
+            "system-shutdown",
+            Gtk.ButtonsType.CANCEL
+        );
+        dialog.transient_for = (Gtk.Window) get_toplevel ();
+
+        var continue_button = dialog.add_button (_("Reboot"), Gtk.ResponseType.ACCEPT);
+        continue_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+
+        var result = dialog.run ();
+        dialog.destroy ();
+
+        return result == Gtk.ResponseType.ACCEPT;
+    }
+
+    private void reboot_to_firmware_setup_clicked () {
+        if (confirm_reboot_to_firmware_setup_action ()) {
+            var login_manager = LoginManager.get_instance ();
+
+            login_manager.set_reboot_to_firmware_setup ();
+            login_manager.reboot ();
         }
     }
 

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -257,7 +257,7 @@ public class About.OperatingSystemView : Gtk.Grid {
         }
     }
 
-    private bool confirm_reboot_to_firmware_setup_action () {
+    private Granite.MessageDialog create_confirm_reboot_to_firmware_setup_dialog () {
         var dialog = new Granite.MessageDialog.with_image_from_icon_name (
             _("Restart to firmware setup?"),
             _("This will close all open applications, restart this device, and open the firmware setup screen."),
@@ -269,14 +269,18 @@ public class About.OperatingSystemView : Gtk.Grid {
         var continue_button = dialog.add_button (_("Restart"), Gtk.ResponseType.ACCEPT);
         continue_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
-        var result = dialog.run ();
-        dialog.destroy ();
-
-        return result == Gtk.ResponseType.ACCEPT;
+        return dialog;
     }
 
     private void reboot_to_firmware_setup_clicked () {
-        if (confirm_reboot_to_firmware_setup_action ()) {
+        var dialog = create_confirm_reboot_to_firmware_setup_dialog ();
+        dialog.response.connect ((result) => {
+            dialog.destroy ();
+
+            if (result != Gtk.ResponseType.ACCEPT) {
+                return;
+            }
+
             var login_manager = LoginManager.get_instance ();
 
             if (!login_manager.set_reboot_to_firmware_setup ()) {
@@ -285,7 +289,9 @@ public class About.OperatingSystemView : Gtk.Grid {
             }
 
             login_manager.reboot ();
-        }
+        });
+        
+        dialog.show ();
     }
 
     private static void reset_all_keys (GLib.Settings settings) {

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -125,17 +125,21 @@ public class About.OperatingSystemView : Gtk.Grid {
 
         var settings_restore_button = new Gtk.Button.with_label (_("Restore Default Settings"));
 
+        var reboot_to_firmware_setup_button = new Gtk.Button.with_label (_("Reboot to Firmware Setup"));
+
         var button_grid = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL) {
             hexpand = true,
             layout_style = Gtk.ButtonBoxStyle.END,
             spacing = 6
         };
         button_grid.add (settings_restore_button);
+        button_grid.add (reboot_to_firmware_setup_button);
         button_grid.add (bug_button);
         if (update_button != null) {
             button_grid.add (update_button);
         }
         button_grid.set_child_secondary (settings_restore_button, true);
+        button_grid.set_child_secondary (reboot_to_firmware_setup_button, true);
 
         software_grid = new Gtk.Grid () {
             // The avatar has some built-in margin for shadows

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -133,13 +133,16 @@ public class About.OperatingSystemView : Gtk.Grid {
             spacing = 6
         };
         button_grid.add (settings_restore_button);
-        button_grid.add (reboot_to_firmware_setup_button);
+        button_grid.set_child_secondary (settings_restore_button, true);
+        if (LoginManager.get_instance ().can_reboot_to_firmware_setup ()) {
+            button_grid.add (reboot_to_firmware_setup_button);
+            button_grid.set_child_secondary (reboot_to_firmware_setup_button, true);
+        }
+        button_grid.set_child_secondary (reboot_to_firmware_setup_button, true);
         button_grid.add (bug_button);
         if (update_button != null) {
             button_grid.add (update_button);
         }
-        button_grid.set_child_secondary (settings_restore_button, true);
-        button_grid.set_child_secondary (reboot_to_firmware_setup_button, true);
 
         software_grid = new Gtk.Grid () {
             // The avatar has some built-in margin for shadows


### PR DESCRIPTION
If I ever need to make changes on the firmware (BIOS/UEFI) of my device, I often don't know which key combination to press when starting the device to get there. Windows offers an option to boot directly into BIOS/UEFI. On Linux, I have used https://www.freedesktop.org/software/systemd/man/systemctl.html#--firmware-setup for this so far. This feature adds a button that reboots the device and starts the BIOS/UEFI.

![Bildschirmfoto von 2022-10-30 05 55 54](https://user-images.githubusercontent.com/10796736/198876003-b3f7dc65-0fc5-4390-8199-bf57c17ccac9.png)

![Bildschirmfoto von 2022-10-30 05 56 11](https://user-images.githubusercontent.com/10796736/198876007-f611617f-8481-4866-ac4a-4c3f9876ed80.png)