### PR TITLE
Better (IMHO) icon :-)

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -41,7 +41,7 @@ public class About.Plug : Switchboard.Plug {
             code_name: "io.elementary.settings.system",
             display_name: _("System"),
             description: _("View operating system and hardware information"),
-            icon: "application-x-firmware",
+            icon: "computer",
             supported_settings: settings
         );
     }


### PR DESCRIPTION
Use the `computer` icon instead of `application-x-firmware` which looks less busy to my tired old eyes.