### PR TITLE
l10n: Fix some strings not shown as translated

### DIFF
--- a/src/Views/FirmwareReleaseView.vala
+++ b/src/Views/FirmwareReleaseView.vala
@@ -221,7 +221,12 @@ public class About.FirmwareReleaseView : Gtk.Box {
         if (duration_minutes < 1) {
             install_duration_value_label.label = _("less than a minute");
         } else {
-            install_duration_value_label.label = GLib.ngettext ("%llu minute", "%llu minutes", duration_minutes).printf (duration_minutes);
+            install_duration_value_label.label = dngettext (
+                GETTEXT_PACKAGE,
+                "%llu minute",
+                "%llu minutes",
+                duration_minutes
+            ).printf (duration_minutes);
         }
     }
 

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -403,7 +403,8 @@ public class About.OperatingSystemView : Gtk.Box {
 
                 try {
                     var details = yield update_proxy.get_update_details ();
-                    updates_description.label = ngettext (
+                    updates_description.label = dngettext (
+                        GETTEXT_PACKAGE,
                         "%i update available",
                         "%i updates available",
                         details.packages.length

--- a/src/Widgets/UpdateDetailsDialog.vala
+++ b/src/Widgets/UpdateDetailsDialog.vala
@@ -15,7 +15,8 @@ public class About.UpdateDetailsDialog : Granite.Dialog {
         modal = true;
 
         var title_label = new Gtk.Label (
-            ngettext (
+            dngettext (
+                GETTEXT_PACKAGE,
                 "%u package will be upgraded",
                 "%u packages will be upgraded",
                 packages.get_n_items ()

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,7 @@ switchboard_dep = dependency('switchboard-3')
 switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 
 config_data = configuration_data()
-config_data.set('GETTEXT_PACKAGE', meson.project_name() + '-plug')
+config_data.set('GETTEXT_PACKAGE', gettext_name)
 config_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config_vala = configure_file(
     input: 'Config.vala.in',


### PR DESCRIPTION
Fixes #318

- Use dngettext instead of gettext
- Correct GETTEXT_PACKAGE value

![after1](https://github.com/elementary/switchboard-plug-about/assets/26003928/37f19357-6b1c-450d-b266-aaa085761d0f)

![after2](https://github.com/elementary/switchboard-plug-about/assets/26003928/b326f72c-27fb-4cad-aab8-c380ba57913f)