### PR TITLE
Fix deprecated use of get_style_context ()

### DIFF
--- a/data/OperatingSystemView.css
+++ b/data/OperatingSystemView.css
@@ -1,4 +1,4 @@
-.logo {
+.operating-system-view .logo {
     color: white;
     background-image: linear-gradient(
         to bottom,

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -102,7 +102,7 @@ public class About.OperatingSystemView : Gtk.Box {
             use_markup = true,
             xalign = 0
         };
-        title.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+        title.add_css_class (Granite.STYLE_CLASS_H2_LABEL);
 
         var kernel_version_label = new Gtk.Label ("%s %s".printf (uts_name.sysname, uts_name.release)) {
             selectable = true,
@@ -501,7 +501,7 @@ public class About.OperatingSystemView : Gtk.Box {
         };
 
         var continue_button = dialog.add_button (_("Restore Settings"), Gtk.ResponseType.ACCEPT);
-        continue_button.get_style_context ().add_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
+        continue_button.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
         dialog.response.connect ((response) => {
             dialog.destroy ();

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -35,8 +35,12 @@ public class About.OperatingSystemView : Gtk.Box {
     private Gtk.Stack button_stack;
 
     construct {
+        add_css_class ("operating-system-view");
+
         var style_provider = new Gtk.CssProvider ();
         style_provider.load_from_resource ("io/elementary/settings/system/OperatingSystemView.css");
+
+        Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var uts_name = Posix.utsname ();
 
@@ -69,7 +73,6 @@ public class About.OperatingSystemView : Gtk.Box {
                     logo = new Adw.Avatar (128, "", false) {
                         custom_image = Gdk.Paintable.empty (128, 128)
                     };
-                    logo.get_style_context ().add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
                     logo_overlay.child = logo;
                     logo_overlay.add_overlay (icon);
@@ -77,7 +80,6 @@ public class About.OperatingSystemView : Gtk.Box {
                     // 128 minus 3px padding on each side
                     icon.pixel_size = 128 - 6;
                     icon.add_css_class ("logo");
-                    icon.get_style_context ().add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
                     break;
                 }

--- a/src/Widgets/FirmwareUpdateRow.vala
+++ b/src/Widgets/FirmwareUpdateRow.vala
@@ -42,7 +42,7 @@ public class About.Widgets.FirmwareUpdateRow : Gtk.ListBoxRow {
             halign = Gtk.Align.START,
             hexpand = true
         };
-        device_name_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+        device_name_label.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var version_label = new Gtk.Label (device.get_version ()) {
             wrap = true,


### PR DESCRIPTION
Only non-deprecated use of Gtk.StyleContext is to add a provider for display