### PR TITLE
build: Fix build with fwupd 2.0.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ datadir = join_paths(prefix, get_option('datadir'))
 libdir = join_paths(prefix, get_option('libdir'))
 
 glib_dep = dependency('glib-2.0', version: '>=2.64.0')
-
+fwupd_dep = dependency('fwupd')
 appstream_dep = dependency ('appstream', version: '>=0.12.10')
 
 add_project_arguments(
@@ -29,6 +29,10 @@ vala_flags = []
 
 if glib_dep.version().version_compare ('>=2.73.0')
     vala_flags += ['--define', 'HAS_GLIB_2_73']
+endif
+
+if fwupd_dep.version().version_compare ('>=2.0.0')
+    vala_flags += ['--define', 'HAS_FWUPD_2_0']
 endif
 
 if appstream_dep.version().version_compare('>=1.0')

--- a/src/Views/FirmwareReleaseView.vala
+++ b/src/Views/FirmwareReleaseView.vala
@@ -194,7 +194,11 @@ public class About.FirmwareReleaseView : Gtk.Box {
         stack.visible_child = scrolled_window;
 
         var release_version = release.get_version ();
+#if HAS_FWUPD_2_0
+        if (release.get_flags () == Fwupd.ReleaseFlags.IS_UPGRADE && release_version != device.get_version ()) {
+#else
         if (release.get_flags () == Fwupd.RELEASE_FLAG_IS_UPGRADE && release_version != device.get_version ()) {
+#endif
             update_button.label = _("Update");
             update_button.sensitive = true;
         } else {

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,7 +33,7 @@ shared_module(
     config_vala,
     css_gresource,
     dependencies: [
-        dependency('fwupd'),
+        fwupd_dep,
         glib_dep,
         dependency('gio-2.0'),
         dependency('gobject-2.0'),


### PR DESCRIPTION
- Generally based on [Arch's patch](https://gitlab.archlinux.org/archlinux/packaging/packages/switchboard-plug-about/-/commit/d3716abb1a37b88a427a4227bdfb63dcf915f757).
- The `fwupd_release_get_locations` usage is also inspired by [KDE discover](https://invent.kde.org/plasma/discover/-/blob/v6.2.3/libdiscover/backends/FwupdBackend/FwupdBackend.cpp?ref_type=tags#L203) and [GNOME software](https://github.com/GNOME/gnome-software/blob/011d52b3c3388ca88421edeae8045f24b4f60c9d/plugins/fwupd/gs-plugin-fwupd.c#L542).
- Offline support is [gone](https://github.com/fwupd/fwupd/commit/ee40786de8800201e1676355c0709e947bd95474).
