### PR TITLE
Only translate delimiters and not monetary symbols

### DIFF
--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -829,10 +829,10 @@ public class About.OperatingSystemView : Gtk.Box {
 
                     var animation_target = new Adw.CallbackAnimationTarget ((val) => {
                         ///TRANSLATORS: first value is a percentage, second value is an amount in USD
-                        target_label.label = _("%.0f%% towards $%'5.0f per month goal".printf (
+                        target_label.label = _("%.0f%% towards $%'5.0f per month goal").printf (
                             Math.round (val),
                             target_value
-                        ));
+                        );
 
                         levelbar.value = val / 100.0;
                     });

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -826,14 +826,12 @@ public class About.OperatingSystemView : Gtk.Box {
 
                     int64 percent_complete = sponsors_listing.get_int_member ("percentComplete");
                     double target_value = sponsors_listing.get_double_member ("targetValue");
-                    char currency[20];
-                    Monetary.strfmon (currency, "%5.0n", target_value);
 
                     var animation_target = new Adw.CallbackAnimationTarget ((val) => {
                         ///TRANSLATORS: first value is a percentage, second value is an amount in USD
-                        target_label.label = _("%.0f%% towards %s per month goal".printf (
+                        target_label.label = _("%.0f%% towards $%'5.0f per month goal".printf (
                             Math.round (val),
-                            (string) currency
+                            target_value
                         ));
 
                         levelbar.value = val / 100.0;

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,7 +48,6 @@ shared_module(
         dependency('polkit-gobject-1'),
         dependency('json-glib-1.0'),
         appstream_dep,
-        meson.get_compiler('vala').find_library('monetary', dirs: meson.project_source_root() / 'vapi'),
         meson.get_compiler('vala').find_library('posix'),
         switchboard_dep
     ],

--- a/vapi/monetary.vapi
+++ b/vapi/monetary.vapi
@@ -1,5 +1,0 @@
-[CCode (cheader_filename = "monetary.h")]
-public class Monetary {
-     [CCode(cname = "strfmon")]
-      public static ssize_t strfmon(char[] s, string format, double data);
-}


### PR DESCRIPTION
Addresses https://github.com/elementary/switchboard-plug-about/pull/347#issuecomment-2524541907 and plus correct gettext format while I'm here.

en_US that uses `,` for delimiters:

![Screenshot From 2024-12-07 17-52-08](https://github.com/user-attachments/assets/1a12b217-ffca-4b7a-ab1a-55072a89fffd)

de_DE that uses `.` for delimiters:

![Screenshot From 2024-12-07 17-53-51](https://github.com/user-attachments/assets/8d1c0d4c-06f3-42d6-bbcc-fd1a384928fa)