### PR TITLE
SystemUpdate: Get last refresh time directly from Settings Daemon instead of via GSettings

### DIFF
--- a/src/DBus/SystemUpdate.vala
+++ b/src/DBus/SystemUpdate.vala
@@ -27,5 +27,5 @@ public interface SystemUpdate : Object {
     public abstract async void cancel () throws DBusError, IOError;
     public abstract async void check_for_updates (bool force, bool notify) throws DBusError, IOError;
     public abstract async void update () throws DBusError, IOError;
-    public async int64 get_last_refresh_time () throws DBusError, IOError;
+    public abstract async int64 get_last_refresh_time () throws DBusError, IOError;
 }

--- a/src/DBus/SystemUpdate.vala
+++ b/src/DBus/SystemUpdate.vala
@@ -27,4 +27,5 @@ public interface SystemUpdate : Object {
     public abstract async void cancel () throws DBusError, IOError;
     public abstract async void check_for_updates (bool force, bool notify) throws DBusError, IOError;
     public abstract async void update () throws DBusError, IOError;
+    public async int64 get_last_refresh_time () throws DBusError, IOError;
 }

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -19,8 +19,6 @@
 */
 
 public class About.OperatingSystemView : Gtk.Box {
-    private static Settings update_settings = new Settings ("io.elementary.settings-daemon.system-update");
-
     private static string _bug_url;
     private static string bug_url {
         get {
@@ -511,7 +509,7 @@ public class About.OperatingSystemView : Gtk.Box {
                 updates_title.label = _("Up To Date");
                 updates_description.label = _("Last checked %s").printf (
                     Granite.DateTime.get_relative_datetime (
-                        new DateTime.from_unix_utc (update_settings.get_int64 ("last-refresh-time"))
+                        new DateTime.from_unix_utc (yield update_proxy.get_last_refresh_time ())
                     )
                 );
                 button_stack.visible_child_name = "refresh";

--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -507,11 +507,19 @@ public class About.OperatingSystemView : Gtk.Box {
             case UP_TO_DATE:
                 updates_image.icon_name = "process-completed";
                 updates_title.label = _("Up To Date");
-                updates_description.label = _("Last checked %s").printf (
-                    Granite.DateTime.get_relative_datetime (
-                        new DateTime.from_unix_utc (yield update_proxy.get_last_refresh_time ())
-                    )
-                );
+
+                try {
+                    var last_refresh_time = yield update_proxy.get_last_refresh_time ();
+                    updates_description.label = _("Last checked %s").printf (
+                        Granite.DateTime.get_relative_datetime (
+                            new DateTime.from_unix_utc (last_refresh_time)
+                        )
+                    );
+                } catch (Error e) {
+                    critical ("Failed to get last refresh time from Updates Backend: %s", e.message);
+                    updates_description.label = _("Last checked unknown");
+                }
+
                 button_stack.visible_child_name = "refresh";
                 break;
             case CHECKING:


### PR DESCRIPTION
Fixes #342

See also: https://github.com/elementary/settings-daemon/pull/175#issue-2760622522