### PR TITLE
Prevent `software_grid` change vertical position, when content changes

### DIFF
--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -326,7 +326,8 @@ public class About.OperatingSystemView : Gtk.Box {
 
         software_grid = new Gtk.Grid () {
             column_spacing = 32,
-            valign = Gtk.Align.CENTER,
+            margin_top = 12,
+            valign = Gtk.Align.START,
             vexpand = true,
             hexpand = true
         };


### PR DESCRIPTION
This improves UX, making elements in `software_grid` not change their position and therefore be predictable and "steady".