### PR TITLE
Control: bump runtime dep for settings daemon

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Homepage: https://github.com/elementary/switchboard-plug-about
 
 Package: io.elementary.settings.system
 Architecture: any
-Depends: io.elementary.settings-daemon (>= 8.0.0),
+Depends: io.elementary.settings-daemon (>= 8.2.0),
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: io.elementary.feedback, fwupd, switcheroo-control


### PR DESCRIPTION
Depends on new API in the settings daemon to show updates download progress

Merge after: https://github.com/elementary/settings-daemon/pull/181