### PR TITLE
OperatingSystemView: more explicit restart directions

### DIFF
--- a/src/Views/OperatingSystemView.vala
+++ b/src/Views/OperatingSystemView.vala
@@ -592,8 +592,8 @@ public class About.OperatingSystemView : Gtk.Box {
                 break;
             case RESTART_REQUIRED:
                 updates_image.icon_name = "system-reboot";
-                updates_title.label = _("Restart Required");
-                updates_description.label = _("A restart is required to finish installing updates");
+                updates_title.label = _("Restart to install pending updates");
+                updates_description.label = _("Updates have been downloaded. A restart is required to finish installing them.");
                 button_stack.visible_child_name = "blank";
                 break;
             case ERROR:


### PR DESCRIPTION
Related to https://github.com/elementary/switchboard/discussions/343

Make it more clear that this is instructional text and not just informational text. Explicitly communicate that updates have been downloaded. Also makes the text a little less redunant

![Screenshot from 2025-02-20 13 27 27](https://github.com/user-attachments/assets/9deb45a1-4aa7-49a2-88da-c2a1ad1b55a6)
