### PR TITLE
HardwareView: Fallback to "Unknown Processor" instead of blank CPU name

### DIFF
--- a/src/Views/HardwareView.vala
+++ b/src/Views/HardwareView.vala
@@ -280,14 +280,19 @@ public class About.HardwareView : Gtk.Box {
                 result += "\n";
             }
 
+            string cpu_name = _("Unknown Processor");
+            if (cpu.key.length > 0) {
+                cpu_name = clean_name (cpu.key);
+            }
+
             if (cpu.@value == 2) {
-                result += _("Dual-Core %s").printf (clean_name (cpu.key));
+                result += _("Dual-Core %s").printf (cpu_name);
             } else if (cpu.@value == 4) {
-                result += _("Quad-Core %s").printf (clean_name (cpu.key));
+                result += _("Quad-Core %s").printf (cpu_name);
             } else if (cpu.@value == 6) {
-                result += _("Hexa-Core %s").printf (clean_name (cpu.key));
+                result += _("Hexa-Core %s").printf (cpu_name);
             } else {
-                result += "%u \u00D7 %s ".printf (cpu.@value, clean_name (cpu.key));
+                result += "%u \u00D7 %s ".printf (cpu.@value, cpu_name);
             }
         }
 


### PR DESCRIPTION
Fixes #397

We can DRY as a side effect.

<img width="851" height="792" alt="スクリーンショット 2025-12-13 10 29 00" src="https://github.com/user-attachments/assets/f2a014f8-51ca-463b-8b59-18793fbad4da" />

